### PR TITLE
param changes

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -135,21 +135,21 @@ class Params
           title = "Do Unlocked Weapons Automatically Unlock Their Standard Magazine?";
           values[] = {1,0};
           texts[] =  {"Yes","No"};
-          default = 0;
+          default = 1;
      };
      class allowGuidedLaunchers
      {
           title = "Should Guided Launchers become unlocked?";
           values[] = {1,0};
           texts[] =  {"Yes","No"};
-          default = 0;
+          default = 1;
      };
      class allowUnlockedExplosives
      {
           title = "Should Explosives become unlocked?";
           values[] = {1,0};
           texts[] =  {"Yes","No"};
-          default = 0;
+          default = 1;
      };
      class Spacer10
      {


### PR DESCRIPTION
Default params changed to allow guided launchers to be unlocked, ammo to unlock with weapons, and explosives to unlock.